### PR TITLE
Add external internship steps

### DIFF
--- a/pages/tirocinio.md
+++ b/pages/tirocinio.md
@@ -13,7 +13,7 @@ permalink: tirocinio
 
 ## Come funziona il tirocinio 
 
-### Come richiedere il tirocinio 
+### Come richiedere il tirocinio (interno)
 
 ## Tirocini e Professori
 
@@ -78,6 +78,25 @@ permalink: tirocinio
 
 <!-- | [Monti Angelo](https://corsidilaurea.uniroma1.it/it/users/angelomontiuniroma1it) | - | -->
 <!-- | [Sterbini Andrea](https://corsidilaurea.uniroma1.it/it/users/andreasterbiniuniroma1it) | E-Learning, algoritmi, modellazione bayesiana del peer-assessment | -->
+
+### Come richiedere il tirocinio (esterno)
+
+Questo iter è quello standard, in caso l'azienda pubblica un annuncio su Jobsoul, facendo seguire una candidatura spontanea dello studente.
+Non sempre è così, ad esempio se c'è già un contatto diretto preesistente tra azienda e studente. Tuttavia, cambiano solo i primi passaggi ed è una casistica meno diffusa.
+
+1. L'azienda procede a pubblicare l'annuncio su Jobsoul, e attende la sua approvazione
+2. In caso ci siano stati già accordi tra studente e azienda, ma l'annuncio viene pubblicato senza il proprio corso di laurea come target, si può chiedere al prof. Gorla di aggiungerlo, spiegando la situazione
+3. Ci si candida su Jobsoul all'annuncio trovato
+4. L'azienda sperabilmente accetta la candidatura
+5. Il prof. Gorla ti chiederà se hai un relatore o di default vuoi usare lui - controlla se c'è qualche professore con cui ti trovi bene che tratta gli stessi argomenti del tirocinio esterno, potrebbe essere una buona idea
+6. Il prof. Gorla approva il progetto formativo
+7. L'azienda, per prima, stamperà il progetto formativo da Jobsoul (tu non puoi) e te lo invierà via mail già firmato - in caso contrario, contattali
+8. Ora lo firmi tu e lo invii al prof. Gorla, per la terza e ultima firma da parte dell'Università
+9. Scarichi il modulo di assegnazione tirocinio, analogamente a quello interno, e lo fai firmare al relatore, che sia il prof. Gorla o un altro che hai precedentemente scelto
+10. Invii anche questo modulo al prof. Gorla, ovviamente se non l'ha già firmato lui
+11. Ti restituirà il progetto formativo, ora completo delle 3 firme
+12. Deve essere tutto inviato alla segreteria attraverso il form Google, assieme ad altri moduli che devi consegnare. Il cronogramma contiene tutto, appena avranno finito la transizione dal vecchio sito studiareinformatica
+13. Finalmente inizi. Per sicurezza, chiedi al prof. Gorla se è tutto ok
 
 ## FAQ 
 


### PR DESCRIPTION
Siccome fin troppe persone chiedono informazioni sul (lungo) iter del tirocinio esterno, pensavo fosse un'idea integrarlo nella pagina apposita.

Riporto il mio elenco che avevo fatto quando me lo chiedeva qualcuno, e ciò che poi ho seguito io. Ci possono essere piccole variazioni se l'azienda non pubblica l'annuncio ma hai contatti diretti, però nella quasi totalità dei casi di chi chiede è così.