### PR TITLE
feat: dismissible data-driven announcement banner

### DIFF
--- a/assets/_courses.scss
+++ b/assets/_courses.scss
@@ -149,7 +149,7 @@
 .prof_img {
     width: var(--pfp-width);
     border-radius: 100%;
-    border: 3.5px solid #dedede;
+    border: 3.5px solid var(--prof-img-border-color);
     margin: 0 0 3px 0;
 }
 
@@ -175,7 +175,7 @@
 }
 
 .class_icon {
-    color: #8e9693;
+    color: var(--social-icon-color);
     margin: 0 12px 0 12px;
 }
 
@@ -215,10 +215,10 @@
 /*      B A D G E S     P O P U P       */
 
 .explore_badges, .course_mat {
-    background-color: #eeeeee;
+    background-color: var(--gray-200);
     font-family: 'DM Sans';
     font-weight: 200;
-    color: #252d3f;
+    color: var(--body-font-color);
     height: 28px;
     display: flex;
     justify-content: center;

--- a/assets/_curators.scss
+++ b/assets/_curators.scss
@@ -4,6 +4,10 @@
     --border-color: #dedede;
 }
 
+[data-theme="dark"] {
+    --border-color: #555b62;
+}
+
 @media screen and (min-width: 100px) {
     .curatorList {
         display: flex;
@@ -124,7 +128,7 @@
 }
 
 .curSocialIcon {
-    color: #8e9693;
+    color: var(--social-icon-color);
     margin: 0 15px 0 15px;
 }
 

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -18,3 +18,97 @@
     display: block;
   }
 }
+
+// -------------------------------------------------------
+// Theme toggle — attribute-based dark/light mode override
+// Specificity :root[attr] (0,2,0) beats :root (0,1,0)
+// -------------------------------------------------------
+:root[data-theme="dark"] {
+  @include theme-dark;
+  color-scheme: dark;
+}
+
+:root[data-theme="light"] {
+  @include theme-light;
+  color-scheme: light;
+}
+
+// -------------------------------------------------------
+// Breadcrumb navigation
+// -------------------------------------------------------
+.breadcrumb-nav {
+  font-size: var(--font-size-smaller);
+  color: var(--gray-500);
+  padding: $padding-8 $padding-16;
+
+  ol {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0;
+    margin: 0;
+    gap: 0.25rem;
+  }
+
+  li {
+    display: flex;
+    align-items: center;
+
+    &:not(:last-child)::after {
+      content: "›";
+      margin-left: 0.5rem;
+      color: var(--gray-500);
+    }
+
+    &[aria-current="page"] {
+      color: var(--body-font-color);
+    }
+  }
+
+  a {
+    color: var(--color-link);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+// -------------------------------------------------------
+// Back-to-top button
+// -------------------------------------------------------
+.back-to-top {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 100;
+  background: var(--body-background);
+  color: var(--body-font-color);
+  border: 1px solid var(--gray-200);
+  border-radius: 50%;
+  width: 2.5rem;
+  height: 2.5rem;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, background-color 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &.visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  &:hover {
+    background: var(--gray-100);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-link);
+    outline-offset: 2px;
+  }
+}

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -112,3 +112,70 @@
     outline-offset: 2px;
   }
 }
+
+// -------------------------------------------------------
+// Announcement banner
+// -------------------------------------------------------
+.announcement-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: $padding-8 $padding-16;
+  margin-bottom: $padding-8;
+  border-radius: var(--border-radius);
+  font-size: var(--font-size-smaller);
+  gap: $padding-8;
+
+  &-message {
+    flex: 1;
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+    }
+  }
+
+  &-close {
+    background: none;
+    border: none;
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+    color: inherit;
+    opacity: 0.7;
+    padding: $padding-4;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--border-radius);
+
+    &:hover {
+      opacity: 1;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-link);
+      outline-offset: 2px;
+    }
+  }
+}
+
+.banner-info {
+  background: rgba(100, 180, 255, 0.15);
+  border-left: 4px solid var(--color-link);
+  color: var(--body-font-color);
+}
+
+.banner-warning {
+  background: rgba(255, 221, 102, 0.15);
+  border-left: 4px solid #fd6;
+  color: var(--body-font-color);
+}
+
+.banner-critical {
+  background: rgba(255, 102, 102, 0.15);
+  border-left: 4px solid #f66;
+  color: var(--body-font-color);
+}

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -134,10 +134,9 @@
 
   &-track {
     position: relative;
-    display: inline-flex;
-    align-items: center;
-    width: 3.25rem;
-    height: 1.75rem;
+    display: inline-block;
+    width: 2.75rem;
+    height: 1.5rem;
     border-radius: 999px;
     background: var(--gray-200);
     border: 1px solid var(--gray-300);
@@ -152,35 +151,32 @@
 
   &-thumb {
     position: absolute;
+    top: 50%;
     left: 0.2rem;
-    width: 1.25rem;
-    height: 1.25rem;
+    transform: translateY(-50%);
+    width: 1.1rem;
+    height: 1.1rem;
     border-radius: 50%;
     background: #fff;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
-    transition: transform 0.2s ease;
-    z-index: 1;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.25);
+    transition: left 0.2s ease;
   }
 
   input:checked ~ .toggle-switch-track .toggle-switch-thumb {
-    transform: translateX(1.5rem);
+    left: calc(100% - 1.1rem - 0.2rem);
   }
 
   &-icon {
-    position: absolute;
-    font-size: 0.65rem;
+    font-size: 0.85rem;
     line-height: 1;
-    font-style: normal;
-    font-weight: 700;
-    color: var(--gray-500);
-    transition: opacity 0.15s ease;
+    color: var(--body-font-color);
 
-    &--off { left: 0.375rem; }
-    &--on  { right: 0.375rem; color: #fff; opacity: 0; }
+    &--light { display: inline; }
+    &--dark  { display: none; }
   }
 
-  input:checked ~ .toggle-switch-track .toggle-switch-icon--off { opacity: 0; }
-  input:checked ~ .toggle-switch-track .toggle-switch-icon--on  { opacity: 1; }
+  input:checked ~ .toggle-switch-track ~ .toggle-switch-icon--light { display: none; }
+  input:checked ~ .toggle-switch-track ~ .toggle-switch-icon--dark  { display: inline; }
 
   &:focus-within .toggle-switch-track {
     outline: 2px solid var(--color-link);

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -179,3 +179,77 @@
   border-left: 4px solid #f66;
   color: var(--body-font-color);
 }
+
+// -------------------------------------------------------
+// Announcement modal
+// -------------------------------------------------------
+.announcement-modal {
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  max-width: 560px;
+  width: calc(100% - 2rem);
+  max-height: calc(100vh - 4rem);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--gray-200);
+  background: var(--body-background);
+  color: var(--body-font-color);
+  padding: $padding-16;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.24);
+  display: flex;
+  flex-direction: column;
+  gap: $padding-8;
+
+  &::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(4px);
+  }
+
+  &-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: $padding-8;
+  }
+
+  &-title {
+    font-weight: 600;
+    font-size: 1rem;
+    margin: 0;
+  }
+
+  &-body {
+    font-size: var(--font-size-smaller);
+    line-height: 1.6;
+
+    a {
+      color: var(--color-link);
+      text-decoration: underline;
+    }
+  }
+
+  &-close {
+    background: none;
+    border: none;
+    font-size: 1.25rem;
+    line-height: 1;
+    cursor: pointer;
+    color: inherit;
+    opacity: 0.7;
+    padding: $padding-4;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--border-radius);
+
+    &:hover { opacity: 1; }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-link);
+      outline-offset: 2px;
+    }
+  }
+}

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -166,17 +166,17 @@
     left: calc(100% - 1.1rem - 0.2rem);
   }
 
-  &-icon {
-    font-size: 0.85rem;
-    line-height: 1;
+  &-label {
+    font-size: var(--font-size-smaller);
     color: var(--body-font-color);
+    white-space: nowrap;
 
-    &--light { display: inline; }
-    &--dark  { display: none; }
+    &--on  { display: none; }
+    &--off { display: inline; }
   }
 
-  input:checked ~ .toggle-switch-track ~ .toggle-switch-icon--light { display: none; }
-  input:checked ~ .toggle-switch-track ~ .toggle-switch-icon--dark  { display: inline; }
+  input:checked ~ .toggle-switch-track ~ .toggle-switch-label .toggle-switch-label--off { display: none; }
+  input:checked ~ .toggle-switch-track ~ .toggle-switch-label .toggle-switch-label--on  { display: inline; }
 
   &:focus-within .toggle-switch-track {
     outline: 2px solid var(--color-link);

--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -114,6 +114,81 @@
 }
 
 // -------------------------------------------------------
+// Toggle switch — used for dark mode + DSA font
+// -------------------------------------------------------
+.toggle-switch {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+  padding: $padding-4 $padding-8;
+
+  input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    pointer-events: none;
+  }
+
+  &-track {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    width: 3.25rem;
+    height: 1.75rem;
+    border-radius: 999px;
+    background: var(--gray-200);
+    border: 1px solid var(--gray-300);
+    transition: background 0.2s ease, border-color 0.2s ease;
+    flex-shrink: 0;
+  }
+
+  input:checked ~ &-track {
+    background: var(--color-link);
+    border-color: var(--color-link);
+  }
+
+  &-thumb {
+    position: absolute;
+    left: 0.2rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+    transition: transform 0.2s ease;
+    z-index: 1;
+  }
+
+  input:checked ~ .toggle-switch-track .toggle-switch-thumb {
+    transform: translateX(1.5rem);
+  }
+
+  &-icon {
+    position: absolute;
+    font-size: 0.65rem;
+    line-height: 1;
+    font-style: normal;
+    font-weight: 700;
+    color: var(--gray-500);
+    transition: opacity 0.15s ease;
+
+    &--off { left: 0.375rem; }
+    &--on  { right: 0.375rem; color: #fff; opacity: 0; }
+  }
+
+  input:checked ~ .toggle-switch-track .toggle-switch-icon--off { opacity: 0; }
+  input:checked ~ .toggle-switch-track .toggle-switch-icon--on  { opacity: 1; }
+
+  &:focus-within .toggle-switch-track {
+    outline: 2px solid var(--color-link);
+    outline-offset: 2px;
+  }
+}
+
+// -------------------------------------------------------
 // Announcement banner
 // -------------------------------------------------------
 .announcement-banner {
@@ -196,9 +271,12 @@
   color: var(--body-font-color);
   padding: $padding-16;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.24);
-  display: flex;
   flex-direction: column;
   gap: $padding-8;
+
+  // Explicit display: none when closed — prevents display:flex overriding UA stylesheet
+  &:not([open]) { display: none; }
+  &[open] { display: flex; }
 
   &::backdrop {
     background: rgba(0, 0, 0, 0.5);

--- a/assets/_defaults.scss
+++ b/assets/_defaults.scss
@@ -61,6 +61,10 @@ $hint-colors: (
   @include accent("success", #3bad3b);
   @include accent("danger", #f66);
 
+  --home-page-border-color: #d5d5d5;
+  --prof-img-border-color: #dedede;
+  --social-icon-color: #4a5568;
+
   --course-dash-background: #F9F9F9;
   --course-panel-background: #E2E3E7;
 
@@ -123,6 +127,10 @@ $hint-colors: (
   @include accent("info", #6bf);
   @include accent("success", #3bad3b);
   @include accent("danger", #f66);
+
+  --home-page-border-color: #4a4f55;
+  --prof-img-border-color: #555b62;
+  --social-icon-color: #9aa5b4;
 
   --course-dash-background: #3E444A;
   --course-panel-background: #454C52;

--- a/assets/_general.scss
+++ b/assets/_general.scss
@@ -1,41 +1,45 @@
+// Metric-normalized OpenDyslexic — size-adjust + line metric overrides
+// bring glyph dimensions close to DM Sans, eliminating layout shift on switch.
+// WCAG 1.4.12: line-height ≥ 1.5, word-spacing ≥ 0.16em applied in .dyslexic.
 @font-face {
     font-family: 'OpenDyslexic';
     src: url('opendyslexic/OpenDyslexic-Regular.woff2') format('woff2');
+    size-adjust: 82%;
+    ascent-override: 94%;
+    descent-override: 24%;
+    line-gap-override: 0%;
 }
 
 @font-face {
     font-family: 'OpenDyslexic';
     src: url('opendyslexic/OpenDyslexic-Bold.woff2') format('woff2');
     font-weight: bold;
+    size-adjust: 82%;
+    ascent-override: 94%;
+    descent-override: 24%;
+    line-gap-override: 0%;
 }
-
 
 @font-face {
     font-family: 'OpenDyslexic';
     src: url('opendyslexic/OpenDyslexic-Italic.woff2') format('woff2');
     font-style: italic;
+    size-adjust: 82%;
+    ascent-override: 94%;
+    descent-override: 24%;
+    line-gap-override: 0%;
 }
 
 .dyslexic *:not([class*="fa-"]):not(.katex):not(.katex *) {
     font-family: 'OpenDyslexic', sans-serif !important;
+    line-height: 1.5 !important;
+    word-spacing: 0.16em !important;
 }
 
-.dyslexic h1 {
-    font-family: 'OpenDyslexic', sans-serif !important;
-}
-
-.dyslexic h2 {
-    font-family: 'OpenDyslexic', sans-serif !important;
-}
-
-.dyslexic h3 {
-    font-family: 'OpenDyslexic', sans-serif !important;
-}
-
-.dyslexic h4 {
-    font-family: 'OpenDyslexic', sans-serif !important;
-}
-
+.dyslexic h1,
+.dyslexic h2,
+.dyslexic h3,
+.dyslexic h4,
 .dyslexic h5 {
     font-family: 'OpenDyslexic', sans-serif !important;
 }

--- a/assets/_general.scss
+++ b/assets/_general.scss
@@ -18,9 +18,6 @@
 
 .dyslexic *:not([class*="fa-"]):not(.katex):not(.katex *) {
     font-family: 'OpenDyslexic', sans-serif !important;
-    font-size-adjust: .45;
-    letter-spacing: -0.03em;
-    word-spacing: -0.1em;
 }
 
 .dyslexic h1 {

--- a/assets/_home.scss
+++ b/assets/_home.scss
@@ -1,5 +1,5 @@
 a.home-button-link {
-    color: white !important;
+    color: rgb(var(--tw-accent-rgb)) !important;
 }
 
 a.home-button-link:hover {
@@ -20,7 +20,7 @@ a.home-button-link:hover {
         height: 370px;
         margin: 10px;
         border-radius: 12px;
-        border: 2px solid #d5d5d5;
+        border: 2px solid var(--home-page-border-color);
         display: flex;
         flex-direction: column;
         justify-content: end;
@@ -34,7 +34,7 @@ a.home-button-link:hover {
         height: 370px;
         margin: 10px;
         border-radius: 12px;
-        border: 2px solid #d5d5d5;
+        border: 2px solid var(--home-page-border-color);
         display: flex;
         flex-direction: column;
         justify-content: end;
@@ -52,7 +52,7 @@ a.home-button-link:hover {
         height: 370px;
         margin: 10px;
         border-radius: 12px;
-        border: 2px solid #d5d5d5;
+        border: 2px solid var(--home-page-border-color);
         display: flex;
         flex-direction: column;
         justify-content: end;
@@ -206,11 +206,11 @@ a.home-button-link:hover {
 }
 
 .explore_more {
-    background-color: #eeeeee;
+    background-color: var(--gray-200);
     font-family: 'DM Sans';
     font-weight: 200;
     font-size: 18px;
-    color: #252d3f;
+    color: var(--body-font-color);
     width: 120px;
     height: 28px;
     display: flex;

--- a/assets/_home.scss
+++ b/assets/_home.scss
@@ -1,5 +1,5 @@
 a.home-button-link {
-    color: rgb(var(--tw-accent-rgb)) !important;
+    color: #{"rgb(var(--tw-accent-rgb))"} !important;
 }
 
 a.home-button-link:hover {

--- a/assets/index.css
+++ b/assets/index.css
@@ -17,6 +17,9 @@
     --tw-faint-rgb: 203 213 225;
     --sapienza-opacity: 0.22;
     --icon-info-color: #1a73e8;
+    --icon-warn-color: #b07d00;
+    --icon-tip-color: #1a7f37;
+    --separator-color: #c0c4cc;
   }
 
   [data-theme="dark"] {
@@ -26,6 +29,9 @@
     --tw-faint-rgb: 38 66 129;
     --sapienza-opacity: 0.05;
     --icon-info-color: #74C0FC;
+    --icon-warn-color: #FFD43B;
+    --icon-tip-color: #3fb950;
+    --separator-color: #444;
   }
 }
 

--- a/assets/index.css
+++ b/assets/index.css
@@ -15,7 +15,7 @@
     --tw-accent-rgb: 30 41 59;
     --tw-diamond-rgb: 59 130 246;
     --tw-faint-rgb: 203 213 225;
-    --sapienza-opacity: 0.14;
+    --sapienza-opacity: 0.22;
     --icon-info-color: #1a73e8;
   }
 

--- a/assets/index.css
+++ b/assets/index.css
@@ -15,7 +15,7 @@
     --tw-accent-rgb: 30 41 59;
     --tw-diamond-rgb: 59 130 246;
     --tw-faint-rgb: 203 213 225;
-    --sapienza-opacity: 0.22;
+    --sapienza-opacity: 0.30;
     --icon-info-color: #1a73e8;
     --icon-warn-color: #b07d00;
     --icon-tip-color: #1a7f37;

--- a/assets/index.css
+++ b/assets/index.css
@@ -7,6 +7,24 @@
 /*     src: url('minecraft.woff') format('woff'); */
 /* } */
 
+/* Theme-adaptive color tokens for homepage */
+@layer base {
+  :root {
+    /* Light theme (default) */
+    --tw-primary-rgb: 248 250 252;
+    --tw-accent-rgb: 30 41 59;
+    --tw-diamond-rgb: 59 130 246;
+    --tw-faint-rgb: 203 213 225;
+  }
+
+  [data-theme="dark"] {
+    --tw-primary-rgb: 19 36 65;
+    --tw-accent-rgb: 255 255 255;
+    --tw-diamond-rgb: 45 88 181;
+    --tw-faint-rgb: 38 66 129;
+  }
+}
+
 @font-face {
     font-family: 'OpenDyslexic';
     src: url('opendyslexic/OpenDyslexic-Regular.woff2') format('woff2');
@@ -91,7 +109,7 @@ a {
     @apply scale-100;
   }
 }
-     
+
 .minecraft {
     font-family: 'Minecraft' !important;
     text-shadow: 2px 2px black;

--- a/assets/index.css
+++ b/assets/index.css
@@ -15,6 +15,8 @@
     --tw-accent-rgb: 30 41 59;
     --tw-diamond-rgb: 59 130 246;
     --tw-faint-rgb: 203 213 225;
+    --sapienza-opacity: 0.14;
+    --icon-info-color: #1a73e8;
   }
 
   [data-theme="dark"] {
@@ -22,6 +24,8 @@
     --tw-accent-rgb: 255 255 255;
     --tw-diamond-rgb: 45 88 181;
     --tw-faint-rgb: 38 66 129;
+    --sapienza-opacity: 0.05;
+    --icon-info-color: #74C0FC;
   }
 }
 
@@ -57,33 +61,39 @@
 
 .sapienza-1 {
     background-image: url('https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fthumbs.dreamstime.com%2Fb%2Fmain-entrance-university-city-studies-la-sapienza-roma-ital-italy-90047500.jpg&f=1&nofb=1&ipt=3ef1bb17eb72a538f7c7586a7e45e11cff3b6acfd83bb27975920b70b95632ae&ipo=images');
-    @apply bg-cover opacity-5;
+    @apply bg-cover;
+    opacity: var(--sapienza-opacity);
 }
 
 
 .sapienza-2 {
     background-image: url('https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fc2.staticflickr.com%2F6%2F5106%2F5562273833_3f0ce81f73_b.jpg&f=1&nofb=1&ipt=01e4668ad3f73c8372034ccfb8db9334d770ebf67a461382675d766f41d28603&ipo=images');
-    @apply bg-cover opacity-5;
+    @apply bg-cover;
+    opacity: var(--sapienza-opacity);
 }
 
 .sapienza-3 {
     background-image: url('https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Flive.staticflickr.com%2F65535%2F52899945700_be1f8b6bae_b.jpg&f=1&nofb=1&ipt=e02870b6e647ed88eb80b73e1b77ff24c84d3adf6106064bd52a085cd61a56d3&ipo=images');
-    @apply bg-cover opacity-5;
+    @apply bg-cover;
+    opacity: var(--sapienza-opacity);
 }
 
 .sapienza-4 {
     background-image: url('https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.casilinanews.it%2Fwp-content%2Fuploads%2F2016%2F07%2Fsapienza.jpg&f=1&nofb=1&ipt=32d5a57a1a68af621d870b7325ccfd96291e090d5a9f5a3690808eb63559405d&ipo=images');
-    @apply bg-cover opacity-5;
+    @apply bg-cover;
+    opacity: var(--sapienza-opacity);
 }
 
 .sapienza-5 {
     background-image: url('https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Froma.metropolitanmagazine.it%2Fwp-content%2Fuploads%2F2021%2F05%2FVilla-Mirafiori.jpg&f=1&nofb=1&ipt=da973e2ebf807f0f3b1f5d40dddd23e02ae43e9133c7c4f9a20a30cdc7cafa9a');
-    @apply bg-cover opacity-5;
+    @apply bg-cover;
+    opacity: var(--sapienza-opacity);
 }
 
 .sapienza-6 {
     background-image: url('https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia.meer.com%2Fattachments%2Fd98e16519c30d08cfb11b738773e7346466fdd6c%2Fstore%2Ffill%2F690%2F388%2F3959f1792f03229f1f990b55f6edc923b958bd154945e6a4d032044e6217%2FVilla-Mirafiori-veduta-generale-foto-Roberto-Luciani.jpg&f=1&nofb=1&ipt=9377fc1a19606da3161020958e218c94b25d8e94697d7ad85fc054d9bd93dea7');
-    @apply bg-cover opacity-5;
+    @apply bg-cover;
+    opacity: var(--sapienza-opacity);
 }
 
 nav  > a {

--- a/data/announcements.json
+++ b/data/announcements.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "welcome-2026",
+    "level": "info",
+    "message": "Welcome to the new semester! Check the updated timetables.",
+    "messageIT": "Benvenuti al nuovo semestre! Consultate gli orari aggiornati.",
+    "url": null,
+    "expiresAt": "2026-03-15T00:00:00Z"
+  }
+]

--- a/data/announcements.json
+++ b/data/announcements.json
@@ -1,10 +1,1 @@
-[
-  {
-    "id": "welcome-2026",
-    "level": "info",
-    "message": "Welcome to the new semester! Check the updated timetables.",
-    "messageIT": "Benvenuti al nuovo semestre! Consultate gli orari aggiornati.",
-    "url": null,
-    "expiresAt": "2026-03-15T00:00:00Z"
-  }
-]
+[]

--- a/data/announcements.json
+++ b/data/announcements.json
@@ -1,1 +1,9 @@
-[]
+[
+  {
+    "id": "easter-2026",
+    "level": "info",
+    "message": "Teaching activities will be interrupted for the Easter period from Thursday, April 2 to Tuesday, April 7, 2026. Furthermore, for the Bachelor's degree programs in ACSAI and Informatica, lectures will remain suspended from April 8 to April 14, 2026, to allow midterm exams to take place and to ensure classroom availability for the extraordinary exam sessions.",
+    "messageIT": "Le attività didattiche saranno interrotte per il periodo pasquale da giovedì 2 aprile a martedì 7 aprile 2026. Inoltre, per i corsi di laurea triennale in ACSAI e Informatica, le lezioni rimarranno sospese dall'8 al 14 aprile 2026, per consentire lo svolgimento delle prove intercorso e garantire la disponibilità delle aule per le sessioni d'esame straordinarie.",
+    "expiresAt": "2026-06-30T23:59:59Z"
+  }
+]

--- a/data/announcements.json
+++ b/data/announcements.json
@@ -4,6 +4,9 @@
     "level": "info",
     "message": "Teaching activities will be interrupted for the Easter period from Thursday, April 2 to Tuesday, April 7, 2026. Furthermore, for the Bachelor's degree programs in ACSAI and Informatica, lectures will remain suspended from April 8 to April 14, 2026, to allow midterm exams to take place and to ensure classroom availability for the extraordinary exam sessions.",
     "messageIT": "Le attività didattiche saranno interrotte per il periodo pasquale da giovedì 2 aprile a martedì 7 aprile 2026. Inoltre, per i corsi di laurea triennale in ACSAI e Informatica, le lezioni rimarranno sospese dall'8 al 14 aprile 2026, per consentire lo svolgimento delle prove intercorso e garantire la disponibilità delle aule per le sessioni d'esame straordinarie.",
+    "modal": true,
+    "title": "⚠️ Teaching suspension — Easter 2026",
+    "titleIT": "⚠️ Sospensione lezioni — Pasqua 2026",
     "expiresAt": "2026-06-30T23:59:59Z"
   }
 ]

--- a/hugo.toml
+++ b/hugo.toml
@@ -118,6 +118,7 @@ custom_css = ["css/contributors.css", "assets/*.scss"]
     math = true
     BookTheme = 'auto'
     BookToC = true
+    BookServiceWorker = true
     BookLogo = 'logo.png'
     BookSection = '*'
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -118,7 +118,6 @@ custom_css = ["css/contributors.css", "assets/*.scss"]
     math = true
     BookTheme = 'auto'
     BookToC = true
-    BookServiceWorker = true
     BookLogo = 'logo.png'
     BookSection = '*'
 
@@ -129,3 +128,8 @@ custom_css = ["css/contributors.css", "assets/*.scss"]
     BookCommitPath = 'commit'
     BookEditPath = 'edit/main'
     BookDateFormat = '2 January 2006'
+
+[[server.headers]]
+  for = "**.css"
+  [server.headers.values]
+    Content-Type = "text/css; charset=utf-8"

--- a/i18n/29389.yaml
+++ b/i18n/29389.yaml
@@ -1,0 +1,165 @@
+#
+#   S I T E   G E N E R A L
+#
+
+- id: Search
+  translation: Search something...
+
+- id: EditPage
+  translation: Edit this page
+
+- id: 404_Desc_1
+  translation: The page that you are trying to reach could have been removed,
+
+- id: 404_Desc_2
+  translation: its name could've been edited or it could be not reachable at the moment.
+
+- id: 404_Homepage
+  translation: Go to the homepage
+
+- id: 404_Report
+  translation: Report an issue
+
+- id: DaysOfTheWeek_Monday
+  translation: Mon
+
+- id: DaysOfTheWeek_Tuesday
+  translation: Tue
+
+- id: DaysOfTheWeek_Wednesday
+  translation: Wed
+
+- id: DaysOfTheWeek_Thursday
+  translation: Thu
+
+- id: DaysOfTheWeek_Friday
+  translation: Fri
+
+- id: DaysOfTheWeek_Saturday
+  translation: Sat
+
+- id: DaysOfTheWeek_Sunday
+  translation: Sun
+
+- id: DaysOfTheWeek_Monday_Full
+  translation: Monday
+
+- id: DaysOfTheWeek_Tuesday_Full
+  translation: Tuesday
+
+- id: DaysOfTheWeek_Wednesday_Full
+  translation: Wednesday
+
+- id: DaysOfTheWeek_Thursday_Full
+  translation: Thursday
+
+- id: DaysOfTheWeek_Friday_Full
+  translation: Friday
+
+- id: DaysOfTheWeek_Saturday_Full
+  translation: Saturday
+
+- id: DaysOfTheWeek_Sunday_Full
+  translation: Sunday
+
+
+#
+#   S U B J E C T S   T I M E T A B L E
+#
+
+- id: Subjs_ThisWeekOnly
+  translation: This page displays, for this week, the provisional timetable for the current week of classes. For the following weeks, timetables and/or classrooms will change; it is therefore advisable to keep up-to-date with the Degree Course Attendance page or the Telegram and WhatsApp groups.
+
+- id: Subjs_WorkInProgress
+  translation: Timetable currently being updated. Please do not rely on it for now and try again later!
+
+- id: Subjs_Timetables_Time
+  translation: Time
+
+- id: Subjs_Timetables_AlertsLegend
+  translation: Check the available warnings by clicking on the subject names followed by asterisks
+
+- id: Subjs_TimetablesPerTeaching_Title
+  translation: Timetables per teaching
+
+- id: Subjs_TimetablesPerTeaching_NoTimetable
+  translation: No timetable available for this week. This might be a course whose start of classes has been postponed or whose classes have already ended. It is advisable to stay updated through the 'Attendance' page of the Degree Program or via Telegram and WhatsApp groups.
+
+- id: Subjs_TimetablesPerTeaching_Day
+  translation: Day
+
+- id: Subjs_TimetablesPerTeaching_Time
+  translation: Time
+
+- id: Subjs_TimetablesPerTeaching_Teacher
+  translation: Teacher
+
+- id: Subjs_TimetablesPerTeaching_Classroom
+  translation: Classroom
+
+- id: Subjs_TimetablesPerTeaching_ConstructionSite
+  translation: Temporary classroom (changes from time to time) due to ongoing work in the assigned classroom, for the current classroom look for an announcement from Sapienza or the professor
+
+- id: Subjs_TimetablesPerTeaching_TBA
+  translation: Classroom still to be announced, you can try searching for an announcement from Sapienza or the professor (or click on this link and see if it has been updated in the timetable published by the Secretariat)
+
+- id: Subjs_TimetablesPerTeaching_Telegram_JoinGroup
+  translation: Join the
+
+- id: Subjs_TimetablesPerTeaching_Telegram_TelegramGroup
+  translation: Telegram Group of
+
+- id: Subjs_TimetablesPerTeaching_Telegram_StayUpdated
+  translation: to stay updated on any schedule changes, resources, and course information
+
+- id: Subjs_CustomTimetable_Title
+  translation: Your timetable
+
+- id: Subjs_CustomTimetable_AddButton
+  translation: Add and remove subjects
+
+- id: Subjs_CustomTimetable_CloseMenuButton
+  translation: Close the menu
+
+- id: Subjs_CustomTimetable_SelectMenuTitle
+  translation: Select the subjects you wish to add or remove
+
+#
+#   C O N T A C T S   P A G E
+#
+
+- id: Contacts_Title
+  translation: 🖋 Contacts of the wiki's main curators
+
+- id: Contacts_BadgeMeaning
+  translation: What do the badges mean?
+
+- id: B_Course
+  translation: Course
+
+- id: B_Course_Desc
+  translation: Course of study in which the curator studies/studied during their period of studies at Sapienza
+
+- id: B_CyberSecRepr
+  translation: Representative @ CyberSec
+
+- id: B_CyberSecRepr_Desc
+  translation: The curator is a Cybersecurity Student Representative
+
+- id: B_CSRepr
+  translation: Representative @ CS
+
+- id: B_Stud_CSRepr_Desc
+  translation: Computer Science Student Representative
+
+- id: B_Stud_DIRepr
+  translation: Representative @ DI
+
+- id: B_Stud_DIRepr_Desc
+  translation: Student Representative on the Department Council of Computer Science
+
+- id: DarkMode
+  translation: Dark mode
+
+- id: BackToTop
+  translation: Back to top

--- a/i18n/29389.yaml
+++ b/i18n/29389.yaml
@@ -163,3 +163,6 @@
 
 - id: BackToTop
   translation: Back to top
+
+- id: DismissBanner
+  translation: Dismiss

--- a/i18n/29932.yaml
+++ b/i18n/29932.yaml
@@ -1,0 +1,189 @@
+#
+#   S I T E   G E N E R A L
+#
+
+- id: Search
+  translation: Search something...
+
+- id: EditPage
+  translation: Edit this page
+
+- id: 404_Desc_1
+  translation: The page that you are trying to reach could have been removed,
+
+- id: 404_Desc_2
+  translation: its name could've been edited or it could be not reachable at the moment.
+
+- id: 404_Homepage
+  translation: Go to the homepage
+
+- id: 404_Report
+  translation: Report an issue
+
+- id: DaysOfTheWeek_Monday
+  translation: Mon
+
+- id: DaysOfTheWeek_Tuesday
+  translation: Tue
+
+- id: DaysOfTheWeek_Wednesday
+  translation: Wed
+
+- id: DaysOfTheWeek_Thursday
+  translation: Thu
+
+- id: DaysOfTheWeek_Friday
+  translation: Fri
+
+- id: DaysOfTheWeek_Saturday
+  translation: Sat
+
+- id: DaysOfTheWeek_Sunday
+  translation: Sun
+
+- id: DaysOfTheWeek_Monday_Full
+  translation: Monday
+
+- id: DaysOfTheWeek_Tuesday_Full
+  translation: Tuesday
+
+- id: DaysOfTheWeek_Wednesday_Full
+  translation: Wednesday
+
+- id: DaysOfTheWeek_Thursday_Full
+  translation: Thursday
+
+- id: DaysOfTheWeek_Friday_Full
+  translation: Friday
+
+- id: DaysOfTheWeek_Saturday_Full
+  translation: Saturday
+
+- id: DaysOfTheWeek_Sunday_Full
+  translation: Sunday
+
+
+#
+#   S U B J E C T S   T I M E T A B L E
+#
+
+- id: Subjs_ThisWeekOnly
+  translation: This page displays, for this week, the provisional timetable for the current week of classes. For the following weeks, timetables and/or classrooms will change; it is therefore advisable to keep up-to-date with the Degree Course Attendance page or the Telegram and WhatsApp groups.
+
+- id: Subjs_WorkInProgress
+  translation: Timetable currently being updated. Please do not rely on it for now and try again later!
+
+- id: Subjs_Timetables_Time
+  translation: Time
+
+- id: Subjs_Timetables_AlertsLegend
+  translation: Check the available warnings by clicking on the subject names followed by asterisks
+
+- id: Subjs_TimetablesPerTeaching_Title
+  translation: Timetables per teaching
+
+- id: Subjs_TimetablesPerTeaching_NoTimetable
+  translation: No timetable available for this week. This might be a course whose start of classes has been postponed or whose classes have already ended. It is advisable to stay updated through the 'Attendance' page of the Degree Program or via Telegram and WhatsApp groups.
+
+- id: Subjs_TimetablesPerTeaching_Day
+  translation: Day
+
+- id: Subjs_TimetablesPerTeaching_Time
+  translation: Time
+
+- id: Subjs_TimetablesPerTeaching_Teacher
+  translation: Teacher
+
+- id: Subjs_TimetablesPerTeaching_Classroom
+  translation: Classroom
+
+- id: Subjs_TimetablesPerTeaching_ConstructionSite
+  translation: Temporary classroom (changes from time to time) due to ongoing work in the assigned classroom, for the current classroom look for an announcement from Sapienza or the professor
+
+- id: Subjs_TimetablesPerTeaching_TBA
+  translation: Classroom still to be announced, you can try searching for an announcement from Sapienza or the professor (or click on this link and see if it has been updated in the timetable published by the Secretariat)
+
+- id: Subjs_TimetablesPerTeaching_Telegram_JoinGroup
+  translation: Join the
+
+- id: Subjs_TimetablesPerTeaching_Telegram_TelegramGroup
+  translation: Telegram Group of
+
+- id: Subjs_TimetablesPerTeaching_Telegram_StayUpdated
+  translation: to stay updated on any schedule changes, resources, and course information
+
+- id: Subjs_CustomTimetable_Title
+  translation: Your timetable
+
+- id: Subjs_CustomTimetable_AddButton
+  translation: Add and remove subjects
+
+- id: Subjs_CustomTimetable_CloseMenuButton
+  translation: Close the menu
+
+- id: Subjs_CustomTimetable_SelectMenuTitle
+  translation: Select the subjects you wish to add or remove
+
+#
+#   C O N T A C T S   P A G E
+#
+
+- id: Contacts_Title
+  translation: 🖋 Contacts of the wiki's main curators
+
+- id: Contacts_BadgeMeaning
+  translation: What do the badges mean?
+
+- id: B_Course
+  translation: Course
+
+- id: B_Course_Desc
+  translation: Course of study in which the curator studies/studied during their period of studies at Sapienza
+
+- id: B_Tutor_CAD
+  translation: Tutor
+
+- id: B_Tutor_CAD_Desc
+  translation: The curator collaborates on the content of the site's wikis as part of a tutoring program for overall learning of Computer Science Didactic Area Council ("CAD")
+
+- id: B_Volunteer
+  translation: Volunteer
+
+- id: B_Volunteer_Desc
+  translation: The curator collaborates to the project as a volunteer
+
+- id: B_SSN
+  translation: SSN
+
+- id: B_SSN_Desc
+  translation: The curator is a member of the GitHub organization Sapienza Students Network
+
+- id: B_Cont_Cur
+  translation: Content Curator
+
+- id: B_Cont_Cur_Desc
+  translation: The curator composes/has composed content for the site
+
+- id: B_Code_Dev
+  translation: Code Developer
+
+- id: B_Code_Dev_Desc
+  translation: The curator develops/has developed code for the site
+
+- id: B_Stud_Repr
+  translation: Representative @ CAD
+
+- id: B_Stud_CADRepr_Desc
+  translation: Student Representative on the Didactic Area Council ("CAD") of Computer Science
+
+- id: B_Stud_DIRepr
+  translation: Representative @ DI
+
+- id: B_Stud_DIRepr_Desc
+  translation: Student Representative on the Department Council of Computer Science
+
+- id: DarkMode
+  translation: Dark mode
+
+- id: BackToTop
+  translation: Back to top

--- a/i18n/29932.yaml
+++ b/i18n/29932.yaml
@@ -187,3 +187,6 @@
 
 - id: BackToTop
   translation: Back to top
+
+- id: DismissBanner
+  translation: Dismiss

--- a/i18n/33525.yaml
+++ b/i18n/33525.yaml
@@ -59,3 +59,6 @@
 
 - id: BackToTop
   translation: Torna su
+
+- id: DismissBanner
+  translation: Chiudi

--- a/i18n/33525.yaml
+++ b/i18n/33525.yaml
@@ -53,3 +53,9 @@
 
 - id: B_Stud_Repr_CAD_Desc
   translation: Il curatore è un Rappresentante degli Studenti al Consiglio di Area Didattica ("CAD") di Filosofia
+
+- id: DarkMode
+  translation: Tema scuro
+
+- id: BackToTop
+  translation: Torna su

--- a/i18n/33526.yaml
+++ b/i18n/33526.yaml
@@ -59,3 +59,6 @@
 
 - id: BackToTop
   translation: Torna su
+
+- id: DismissBanner
+  translation: Chiudi

--- a/i18n/33526.yaml
+++ b/i18n/33526.yaml
@@ -53,3 +53,9 @@
 
 - id: B_Stud_Repr_CAD_Desc
   translation: Il curatore è un Rappresentante degli Studenti al Consiglio di Area Didattica ("CAD") di Filosofia
+
+- id: DarkMode
+  translation: Tema scuro
+
+- id: BackToTop
+  translation: Torna su

--- a/i18n/acsai.yaml
+++ b/i18n/acsai.yaml
@@ -268,3 +268,6 @@
 
 - id: BackToTop
   translation: Back to top
+
+- id: DismissBanner
+  translation: Dismiss

--- a/i18n/acsai.yaml
+++ b/i18n/acsai.yaml
@@ -262,3 +262,9 @@
 
 - id: B_Stud_DIRepr_Desc
   translation: Student Representative on the Department Council of Computer Science
+
+- id: DarkMode
+  translation: Dark mode
+
+- id: BackToTop
+  translation: Back to top

--- a/i18n/homepage.yaml
+++ b/i18n/homepage.yaml
@@ -31,3 +31,9 @@
 
 - id: SSN_Repo_Managers
   translation: Repo Managers
+
+- id: DarkMode
+  translation: Dark mode
+
+- id: BackToTop
+  translation: Back to top

--- a/i18n/homepage.yaml
+++ b/i18n/homepage.yaml
@@ -37,3 +37,6 @@
 
 - id: BackToTop
   translation: Back to top
+
+- id: DismissBanner
+  translation: Dismiss

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -268,3 +268,6 @@
 
 - id: BackToTop
   translation: Torna su
+
+- id: DismissBanner
+  translation: Chiudi

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -262,3 +262,9 @@
 
 - id: B_Stud_DIRepr_Desc
   translation: Rappresentante degli Studenti al Consiglio di Dipartimento di Informatica
+
+- id: DarkMode
+  translation: Tema scuro
+
+- id: BackToTop
+  translation: Torna su

--- a/i18n/rooms.yaml
+++ b/i18n/rooms.yaml
@@ -19,3 +19,9 @@
 
 - id: 404_Report
   translation: Report an issue
+
+- id: DarkMode
+  translation: Dark mode
+
+- id: BackToTop
+  translation: Back to top

--- a/i18n/rooms.yaml
+++ b/i18n/rooms.yaml
@@ -25,3 +25,6 @@
 
 - id: BackToTop
   translation: Back to top
+
+- id: DismissBanner
+  translation: Dismiss

--- a/layouts/custom/index-filosofia.html
+++ b/layouts/custom/index-filosofia.html
@@ -4,6 +4,7 @@
 
 <head>
     {{ partial "docs/html-head" . }}
+    {{ partial "docs/inject/head" . }}
 
     <link rel="stylesheet" href="/generated/tailwindcss.css" />
 
@@ -13,7 +14,7 @@
 </head>
 
 <body
-    class="bg-primary prose prose-invert flex min-h-screen max-w-none flex-col lg:prose-base xl:prose-lg 2xl:prose-xl">
+    class="bg-primary prose dark:prose-invert flex min-h-screen max-w-none flex-col lg:prose-base xl:prose-lg 2xl:prose-xl">
     <div class="border-faint h-14 border-b border-dashed">
         <div class="border-faint mx-3 h-full border-l border-r border-dashed sm:mx-14"></div>
     </div>
@@ -21,7 +22,7 @@
 
     <div class="border-faint mx-3 flex flex-grow flex-col border-l border-r border-dashed sm:mx-14">
         <div
-            class="border-faint relative grid place-items-center border-b border-dashed bg-gradient-to-r from-transparent via-gray-800/80 to-transparent p-4">
+            class="border-faint relative grid place-items-center border-b border-dashed bg-gradient-to-r from-transparent via-gray-200/80 dark:via-gray-800/80 to-transparent p-4">
             <span class="text-center">
                 <h1 class="!mb-2">Filosofia</h1>
                 <!--<h1 class="!mb-4 relative">
@@ -48,6 +49,7 @@
                 </a>
 
                 {{ partial "font-toggle" . }}
+                {{ partial "theme-toggle" . }}
             </span>
 
             <div class="diamond top-left"></div>
@@ -62,8 +64,8 @@
             <a href="/33525" class="no-underline home-button-link">
                 <div
                     class="relative flex h-full max-w-none flex-col items-center justify-center bg-gradient-to-t from-blue-800/20 hover:bg-blue-500/20">
-                    <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                        class="w-24 lg:w-36 2xl:w-48" />
+                    <img src="/sapienza-logo.png" alt="Sapienza Università di Roma logo"
+                        class="w-24 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center underline">Filosofia</h2>
                     <p>Triennale</p>
                     <div class="sapienza-5 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -73,8 +75,8 @@
             <a href="/33526" class="no-underline home-button-link">
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-green-800/20 hover:bg-green-500/20 md:border-b-0 md:border-l md:border-r">
-                    <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                        class="w-24 lg:w-36 2xl:w-48" />
+                    <img src="/sapienza-logo.png" alt="Sapienza Università di Roma logo"
+                        class="w-24 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center underline">Filosofia e IA</h2>
                     <p>Triennale</p>
                     <div class="sapienza-6 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -96,12 +98,12 @@
             <div class="diamond bottom-right"></div>
         </div>
         <div class="p-2">
-            <div class="p-2 border-amber-400 border-4">
-                <div>⚠️ <b class="text-amber-400">Attenzione!</b></div>
+            <div class="p-2 border-amber-600 dark:border-amber-400 border-4">
+                <div>⚠️ <b class="text-amber-700 dark:text-amber-400">Attenzione!</b></div>
                 <!-- <br> -->
                 <span>
                     L'unica fonte di informazioni sul tuo corso di laurea legalmente vincolante è il
-                    <a href="https://corsidilaurea.uniroma1.it/"> sito istituzionale di Sapienza </a>                    
+                    <a href="https://corsidilaurea.uniroma1.it/"> sito istituzionale di Sapienza </a>
                 </span>
             </div>
             <div class="diamond bottom-left"></div>
@@ -112,6 +114,8 @@
     <div class="border-faint h-14 border-t border-dashed">
         <div class="border-faint mx-3 h-full border-l border-r border-dashed sm:mx-14"></div>
     </div>
+
+    {{ partial "docs/inject/body" . }}
 </body>
 
 </html>

--- a/layouts/custom/index-filosofia.html
+++ b/layouts/custom/index-filosofia.html
@@ -64,7 +64,7 @@
             <a href="/33525" class="no-underline home-button-link">
                 <div
                     class="relative flex h-full max-w-none flex-col items-center justify-center bg-gradient-to-t from-blue-800/20 hover:bg-blue-500/20">
-                    <img src="/sapienza-logo.png" alt="Sapienza Università di Roma logo"
+                    <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
                         class="w-24 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center underline">Filosofia</h2>
                     <p>Triennale</p>
@@ -75,7 +75,7 @@
             <a href="/33526" class="no-underline home-button-link">
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-green-800/20 hover:bg-green-500/20 md:border-b-0 md:border-l md:border-r">
-                    <img src="/sapienza-logo.png" alt="Sapienza Università di Roma logo"
+                    <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
                         class="w-24 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center underline">Filosofia e IA</h2>
                     <p>Triennale</p>

--- a/layouts/custom/index.html
+++ b/layouts/custom/index.html
@@ -14,7 +14,7 @@
 </head>
 
 <body
-    class="bg-primary prose prose-invert flex min-h-screen max-w-none flex-col lg:prose-base xl:prose-lg 2xl:prose-xl">
+    class="bg-primary prose dark:prose-invert flex min-h-screen max-w-none flex-col lg:prose-base xl:prose-lg 2xl:prose-xl">
     <div class="border-faint h-14 border-b border-dashed">
         <div class="border-faint mx-3 h-full border-l border-r border-dashed sm:mx-14"></div>
     </div>
@@ -22,7 +22,7 @@
 
     <div class="border-faint mx-3 flex flex-grow flex-col border-l border-r border-dashed sm:mx-14">
         <div
-            class="border-faint relative grid place-items-center border-b border-dashed bg-gradient-to-r from-transparent via-gray-800/80 to-transparent p-4">
+            class="border-faint relative grid place-items-center border-b border-dashed bg-gradient-to-r from-transparent via-gray-200/80 dark:via-gray-800/80 to-transparent p-4">
             <span class="text-center">
                 <h1 class="!mb-2">Sapienza Students Network</h1>
                 <!--<h1 class="!mb-4 relative">
@@ -63,6 +63,7 @@
                 </a>
 
                 {{ partial "font-toggle" . }}
+                {{ partial "theme-toggle" . }}
             </span>
 
             <div class="diamond top-left"></div>
@@ -76,8 +77,8 @@
             <a href="/acsai" class="no-underline home-button-link">
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-red-800/20 hover:bg-red-500/20 md:border-none">
-                    <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                        class="w-24 lg:w-36 2xl:w-48" />
+                    <img src="/sapienza-logo.png" alt="Sapienza Università di Roma logo"
+                        class="w-24 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0">ACSAI</h2>
                     <p><!--<strong>33502</strong> -->Bachelor's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -98,8 +99,8 @@
             <a href="/compsci" class="no-underline home-button-link">
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-green-800/20 hover:bg-green-500/20 md:border-b-0 md:border-l md:border-r">
-                    <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                        class="w-24 lg:w-36 2xl:w-48" />
+                    <img src="/sapienza-logo.png" alt="Sapienza Università di Roma logo"
+                        class="w-24 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center">Computer Science</h2>
                     <p><!--<strong>33508</strong> -->Master's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -109,8 +110,8 @@
             <a href="/cybersec" class="no-underline home-button-link">
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-yellow-600/20 hover:bg-yellow-300/20 md:border-b-0 md:border-l md:border-r">
-                    <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                         class="w-24 lg:w-36 2xl:w-48" />
+                    <img src="/sapienza-logo.png" alt="Sapienza Università di Roma logo"
+                         class="w-24 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center">Cybersecurity</h2>
                     <p><!--<strong>33516</strong> -->Master's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -143,8 +144,8 @@
             <div class="diamond bottom-right"></div>
         </div>
         <div class="p-2">
-            <div class="p-2 border-amber-400 border-4">
-                <div>⚠️ <b class="text-amber-400">Warning!</b></div>
+            <div class="p-2 border-amber-600 dark:border-amber-400 border-4">
+                <div>⚠️ <b class="text-amber-700 dark:text-amber-400">Warning!</b></div>
                 <!-- <br> -->
                 <span>
                     The only legally-binding source of information about your course programme is the

--- a/layouts/custom/index.html
+++ b/layouts/custom/index.html
@@ -38,28 +38,28 @@
             <span class="flex flex-wrap gap-3 items-center justify-center sm:flex-row sm:gap-6">
                 <a href="./sapienza-students-network" style="flex: none;" class="flex items-center gap-2 underline-offset-4">
                     About Us
-                    <img class="w-6 !m-0" src="/ssn.png" alt="">
+                    <img class="w-6 !m-0 brightness-0 dark:invert" src="/ssn.png" alt="">
                 </a>
                 <a href="https://t.me/+YLdIByN9WhZiNzA0" style="flex: none;" class="flex items-center gap-2 underline-offset-4">
                     Group
-                    <img class="w-6 !m-0" src="/telegram.svg" alt="">
+                    <img class="w-6 !m-0 brightness-0 dark:invert" src="/telegram.svg" alt="">
                 </a>
                 <!--<a href="https://telegram.me/SapienzaStudentsNetwork"
                     class="flex items-center gap-2 underline-offset-4">
                     Channel
-                    <img class="w-8 !m-0" src="/communication.svg" alt="">
+                    <img class="w-8 !m-0 brightness-0 dark:invert" src="/communication.svg" alt="">
                 </a>
                 <a href="https://discord.sapienzastudents.net/" class="flex items-center gap-2 underline-offset-4">
                     Discord
-                    <img class="w-6 !m-0" src="/headset_mic.svg" alt="">
+                    <img class="w-6 !m-0 brightness-0 dark:invert" src="/headset_mic.svg" alt="">
                 </a>-->
                 <a href="https://github.com/SapienzaStudentsNetwork/sapienzastudentsnetwork.github.io" style="flex: none;" class="flex items-center gap-2 underline-offset-4">
                     GitHub
-                    <img class="w-6 !m-0" src="/github.svg" alt="">
+                    <img class="w-6 !m-0 brightness-0 dark:invert" src="/github.svg" alt="">
                 </a>
                 <a href="rooms" style="flex: none;" class="flex items-center gap-2 underline-offset-4">
                     Rooms
-                    <img class="w-6 !m-0" src="/rooms.svg" alt="">
+                    <img class="w-6 !m-0 brightness-0 dark:invert" src="/rooms.svg" alt="">
                 </a>
 
                 {{ partial "font-toggle" . }}

--- a/layouts/custom/index.html
+++ b/layouts/custom/index.html
@@ -4,6 +4,7 @@
 
 <head>
     {{ partial "docs/html-head" . }}
+    {{ partial "docs/inject/head" . }}
 
     <link rel="stylesheet" href="/generated/tailwindcss.css" />
 
@@ -158,6 +159,8 @@
     <div class="border-faint h-14 border-t border-dashed">
         <div class="border-faint mx-3 h-full border-l border-r border-dashed sm:mx-14"></div>
     </div>
+
+    {{ partial "docs/inject/body" . }}
 </body>
 
 </html>

--- a/layouts/custom/index.html
+++ b/layouts/custom/index.html
@@ -78,7 +78,7 @@
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-red-800/20 hover:bg-red-500/20 md:border-none">
                     <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                        class="w-24 dark:invert lg:w-36 2xl:w-48" />
+                        class="w-24 dark:brightness-0 lg:w-36 2xl:w-48" />
                     <h2 class="!m-0">ACSAI</h2>
                     <p><!--<strong>33502</strong> -->Bachelor's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -89,7 +89,7 @@
                 <div
                         class="relative flex h-full max-w-none flex-col items-center justify-center bg-gradient-to-t from-blue-800/20 hover:bg-blue-500/20">
                     <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                         class="w-24 lg:w-36 2xl:w-48" />
+                         class="w-24 dark:brightness-0 lg:w-36 2xl:w-48" />
                     <h2 class="!m-0">Informatica</h2>
                     <p><!--<strong>33503</strong> -->Bachelor's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -100,7 +100,7 @@
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-green-800/20 hover:bg-green-500/20 md:border-b-0 md:border-l md:border-r">
                     <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                        class="w-24 dark:invert lg:w-36 2xl:w-48" />
+                        class="w-24 dark:brightness-0 lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center">Computer Science</h2>
                     <p><!--<strong>33508</strong> -->Master's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -111,7 +111,7 @@
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-yellow-600/20 hover:bg-yellow-300/20 md:border-b-0 md:border-l md:border-r">
                     <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                         class="w-24 dark:invert lg:w-36 2xl:w-48" />
+                         class="w-24 dark:brightness-0 lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center">Cybersecurity</h2>
                     <p><!--<strong>33516</strong> -->Master's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -122,7 +122,7 @@
                 <div
                         class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-purple-800/20 hover:bg-purple-500/20 md:border-b-0 md:border-l md:border-r">
                     <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                         class="w-24 lg:w-36 2xl:w-48" />
+                         class="w-24 dark:brightness-0 lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center">Data Science</h2>
                     <p><!--<strong>33519</strong> -->Master's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>

--- a/layouts/custom/index.html
+++ b/layouts/custom/index.html
@@ -77,7 +77,7 @@
             <a href="/acsai" class="no-underline home-button-link">
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-red-800/20 hover:bg-red-500/20 md:border-none">
-                    <img src="/sapienza-logo.png" alt="Sapienza Università di Roma logo"
+                    <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
                         class="w-24 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0">ACSAI</h2>
                     <p><!--<strong>33502</strong> -->Bachelor's Degree</p>
@@ -99,7 +99,7 @@
             <a href="/compsci" class="no-underline home-button-link">
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-green-800/20 hover:bg-green-500/20 md:border-b-0 md:border-l md:border-r">
-                    <img src="/sapienza-logo.png" alt="Sapienza Università di Roma logo"
+                    <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
                         class="w-24 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center">Computer Science</h2>
                     <p><!--<strong>33508</strong> -->Master's Degree</p>
@@ -110,7 +110,7 @@
             <a href="/cybersec" class="no-underline home-button-link">
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-yellow-600/20 hover:bg-yellow-300/20 md:border-b-0 md:border-l md:border-r">
-                    <img src="/sapienza-logo.png" alt="Sapienza Università di Roma logo"
+                    <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
                          class="w-24 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center">Cybersecurity</h2>
                     <p><!--<strong>33516</strong> -->Master's Degree</p>

--- a/layouts/custom/index.html
+++ b/layouts/custom/index.html
@@ -78,7 +78,7 @@
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-red-800/20 hover:bg-red-500/20 md:border-none">
                     <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                        class="w-24 dark:brightness-0 lg:w-36 2xl:w-48" />
+                        class="w-24 brightness-0 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0">ACSAI</h2>
                     <p><!--<strong>33502</strong> -->Bachelor's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -89,7 +89,7 @@
                 <div
                         class="relative flex h-full max-w-none flex-col items-center justify-center bg-gradient-to-t from-blue-800/20 hover:bg-blue-500/20">
                     <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                         class="w-24 dark:brightness-0 lg:w-36 2xl:w-48" />
+                         class="w-24 brightness-0 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0">Informatica</h2>
                     <p><!--<strong>33503</strong> -->Bachelor's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -100,7 +100,7 @@
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-green-800/20 hover:bg-green-500/20 md:border-b-0 md:border-l md:border-r">
                     <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                        class="w-24 dark:brightness-0 lg:w-36 2xl:w-48" />
+                        class="w-24 brightness-0 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center">Computer Science</h2>
                     <p><!--<strong>33508</strong> -->Master's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -111,7 +111,7 @@
                 <div
                     class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-yellow-600/20 hover:bg-yellow-300/20 md:border-b-0 md:border-l md:border-r">
                     <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                         class="w-24 dark:brightness-0 lg:w-36 2xl:w-48" />
+                         class="w-24 brightness-0 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center">Cybersecurity</h2>
                     <p><!--<strong>33516</strong> -->Master's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>
@@ -122,7 +122,7 @@
                 <div
                         class="border-faint relative flex h-full flex-col items-center justify-center border-b border-dashed bg-gradient-to-t from-purple-800/20 hover:bg-purple-500/20 md:border-b-0 md:border-l md:border-r">
                     <img src="/icon/ssn-crest.png" alt="Sapienza Università di Roma logo"
-                         class="w-24 dark:brightness-0 lg:w-36 2xl:w-48" />
+                         class="w-24 brightness-0 dark:invert lg:w-36 2xl:w-48" />
                     <h2 class="!m-0 text-center">Data Science</h2>
                     <p><!--<strong>33519</strong> -->Master's Degree</p>
                     <div class="sapienza-4 absolute left-0 top-0 z-[-10] h-full w-full"></div>

--- a/layouts/page/classroom-timetable.html
+++ b/layouts/page/classroom-timetable.html
@@ -3,16 +3,16 @@
 
     <h2>Classroom {{ .Params.classroom }}</h2>
 
-    <blockquote class="book-hint info" style="border-color: #6bf; background-color: rgba(102, 187, 255, 0.1); margin: 1rem 0; padding: .5rem 1rem .5rem .75rem; border-inline-start: .25rem solid #6bf; border-radius: .25rem;">
-        <i class="fa-solid fa-location-pin" style="color: #74C0FC;"></i> <strong>Location</strong>
+    <blockquote class="book-hint info">
+        <i class="fa-solid fa-location-pin" style="color: var(--icon-info-color);"></i> <strong>Location</strong>
         <p>The classroom is on the <strong>{{ .Params.floor }}</strong> of <strong>Building E</strong> in the Viale Regina Elena complex, accessible from <a href="https://www.google.com/maps/place/Viale+Regina+Elena,+295,+00161+Roma+RM">Viale Regina Elena, 295</a>, or <a href="https://www.google.com/maps/place/Via+del+Castro+Laurenziano,+6,+00161+Roma+RM">Via del Castro Laurenziano, 6</a>.</p>
         <br/>
-        <i class="fa-solid fa-chair" style="color: #74C0FC;"></i> <strong>Capacity</strong>
+        <i class="fa-solid fa-chair" style="color: var(--icon-info-color);"></i> <strong>Capacity</strong>
         <p>The classroom has a stated capacity of <strong>{{ .Params.seats }}</strong> seats.</p>
     </blockquote>
 
-    <blockquote class="book-hint warning" style="border-color: #fd6; background-color: rgba(253, 214, 102, 0.1); margin: 1rem 0; padding: .5rem 1rem .5rem .75rem; border-inline-start: .25rem solid #fd6; border-radius: .25rem;">
-        <i class="fa-solid fa-triangle-exclamation" style="color: #FFD43B;"></i> <strong>Warning</strong>
+    <blockquote class="book-hint warning">
+        <i class="fa-solid fa-triangle-exclamation" style="color: var(--icon-warn-color);"></i> <strong>Warning</strong>
         <p>The schedule does not apply in case of <strong>national holidays</strong> or <strong>external reasons</strong> that cause the facility to be <strong>closed</strong>.</p>
     </blockquote>
 
@@ -74,8 +74,8 @@
         </tbody>
     </table>
 
-    <blockquote class="book-hint warning" style="border-color: #fd6; background-color: rgba(253, 214, 102, 0.1); margin: 1rem 0; padding: .5rem 1rem .5rem .75rem; border-inline-start: .25rem solid #fd6; border-radius: .25rem;">
-        <i class="fa-solid fa-triangle-exclamation" style="color: #FFD43B;"></i> <strong>Warning</strong>
+    <blockquote class="book-hint warning">
+        <i class="fa-solid fa-triangle-exclamation" style="color: var(--icon-warn-color);"></i> <strong>Warning</strong>
         <p>The classroom is available as a study room <strong>when not in use for lectures or other institutional events</strong>. Please <strong>check this page daily</strong> to see when the room is known to be occupied for institutional activities and when it should be free. Note that <strong>some lectures or events may not appear on this page</strong>, as it syncs automatically with the <a href="https://www2.uniroma1.it/servizi/aule/default.php">Sapienza GOMP system</a>, where <strong>not all scheduled classes or events are always uploaded</strong>.</p>
     </blockquote>
 

--- a/layouts/page/custom-timetable.html
+++ b/layouts/page/custom-timetable.html
@@ -21,12 +21,14 @@
     </details>
 
     <blockquote class="book-hint tip">
-        <i class="fa-solid fa-lightbulb" style="color: #238636;"></i> {{ T "Subjs_Info_Tip" }}
+        <i class="fa-solid fa-lightbulb" style="color: var(--icon-tip-color);"></i> {{ T "Subjs_Info_Tip" }}
     </blockquote>
 
     <!--
     <blockquote class="book-hint info">
-        <i class="fa-solid fa-circle-info" style="color: #74C0FC;"></i> {{ T "Subjs_DelayedStart" }}
+        <i class="fa-solid fa-circle-info" style="color: var(--icon-info-color);"></i> {{ T "Subjs_EasterHolidays" }}
+        <!--
+        <i class="fa-solid fa-circle-info" style="color: var(--icon-info-color);"></i> {{ T "Subjs_DelayedStart" }}
         {{ if not (in .Permalink "/datasci/") }}
         <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vQKHIj_LtE4_dp5Osq4MIZcVS_gz4nXcFzg8cnWLQXOd7514pKuN1mAt5V8z2WuO4fiDCogNrOolSZl/pubhtml?gid=96416658&single=true">https://docs.google.com/spreadsheets/d/e/2PACX-1vQKHIj_LtE4_dp5Osq4MIZcVS_gz4nXcFzg8cnWLQXOd7514pKuN1mAt5V8z2WuO4fiDCogNrOolSZl/pubhtml?gid=96416658&single=true</a>
         {{ else }}
@@ -136,7 +138,7 @@
                 {{ end }}
             </div>
 
-            <div style="width: 99%; height: 1px; background-color: #444; margin: 20px auto 0 auto;"></div>
+            <div style="width: 99%; height: 1px; background-color: var(--separator-color); margin: 20px auto 0 auto;"></div>
             {{ end }}
         </div>
         <button id="subjsCloseMenu" onclick="closeSubjectsDialog()">

--- a/layouts/page/timetables.html
+++ b/layouts/page/timetables.html
@@ -16,7 +16,7 @@
         </details>
 
         <blockquote class="book-hint tip">
-            <i class="fa-solid fa-lightbulb" style="color: #238636;"></i> {{ T "Subjs_Info_Tip" }}
+            <i class="fa-solid fa-lightbulb" style="color: var(--icon-tip-color);"></i> {{ T "Subjs_Info_Tip" }}
         </blockquote>
 
         <!--

--- a/layouts/page/timetables.html
+++ b/layouts/page/timetables.html
@@ -21,7 +21,9 @@
 
         <!--
         <blockquote class="book-hint info">
-            <i class="fa-solid fa-circle-info" style="color: #74C0FC;"></i> {{ T "Subjs_DelayedStart" }}
+            <i class="fa-solid fa-circle-info" style="color: var(--icon-info-color);"></i> {{ T "Subjs_EasterHolidays" }}
+            <!--
+            <i class="fa-solid fa-circle-info" style="color: var(--icon-info-color);"></i> {{ T "Subjs_DelayedStart" }}
             {{ if not (in .Permalink "/datasci/") }}
             <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vQKHIj_LtE4_dp5Osq4MIZcVS_gz4nXcFzg8cnWLQXOd7514pKuN1mAt5V8z2WuO4fiDCogNrOolSZl/pubhtml?gid=96416658&single=true">https://docs.google.com/spreadsheets/d/e/2PACX-1vQKHIj_LtE4_dp5Osq4MIZcVS_gz4nXcFzg8cnWLQXOd7514pKuN1mAt5V8z2WuO4fiDCogNrOolSZl/pubhtml?gid=96416658&single=true</a>
             {{ else }}

--- a/layouts/partials/docs/brand.html
+++ b/layouts/partials/docs/brand.html
@@ -8,3 +8,4 @@
 </h2>
 
 {{ partial "font-toggle" . }}
+{{ partial "theme-toggle" . }}

--- a/layouts/partials/docs/inject/banner.html
+++ b/layouts/partials/docs/inject/banner.html
@@ -1,0 +1,25 @@
+{{/* Dismissible announcement banners — data-driven from data/announcements.json */}}
+{{ $lang := .Site.Language.Lang }}
+{{ $now := now }}
+{{ range site.Data.announcements }}
+  {{/* Skip expired announcements */}}
+  {{ $expired := false }}
+  {{ with .expiresAt }}
+    {{ if time.AsTime . | lt $now }}{{ $expired = true }}{{ end }}
+  {{ end }}
+  {{ if not $expired }}
+    {{ $msg := .message }}
+    {{ if and (eq $lang "it") .messageIT }}{{ $msg = .messageIT }}{{ end }}
+    {{ $levelClass := printf "banner-%s" (default "info" .level) }}
+    <div class="announcement-banner {{ $levelClass }}" data-announcement-id="{{ .id }}" role="alert">
+      <span class="announcement-banner-message">
+        {{ if .url }}<a href="{{ .url }}">{{ $msg }}</a>{{ else }}{{ $msg }}{{ end }}
+      </span>
+      <button class="announcement-banner-close"
+              aria-label="{{ i18n "DismissBanner" | default "Dismiss" }}"
+              data-dismiss="{{ .id }}">
+        &times;
+      </button>
+    </div>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/docs/inject/banner.html
+++ b/layouts/partials/docs/inject/banner.html
@@ -1,4 +1,4 @@
-{{/* Dismissible announcement banners — data-driven from data/announcements.json */}}
+{{/* Dismissible announcement banners/modals — data-driven from data/announcements.json */}}
 {{ $lang := .Site.Language.Lang }}
 {{ $now := now }}
 {{ range site.Data.announcements }}
@@ -11,6 +11,24 @@
     {{ $msg := .message }}
     {{ if and (eq $lang "it") .messageIT }}{{ $msg = .messageIT }}{{ end }}
     {{ $levelClass := printf "banner-%s" (default "info" .level) }}
+    {{ $title := .title | default "" }}
+    {{ if and (eq $lang "it") .titleIT }}{{ $title = .titleIT }}{{ end }}
+
+    {{ if .modal }}
+    <dialog class="announcement-modal {{ $levelClass }}" id="announcement-modal-{{ .id }}" data-announcement-id="{{ .id }}">
+      <div class="announcement-modal-header">
+        {{ if $title }}<p class="announcement-modal-title">{{ $title }}</p>{{ end }}
+        <button class="announcement-modal-close"
+                aria-label="{{ i18n "DismissBanner" | default "Dismiss" }}"
+                data-dismiss="{{ .id }}">
+          &times;
+        </button>
+      </div>
+      <div class="announcement-modal-body">
+        {{ if .url }}<a href="{{ .url }}">{{ $msg }}</a>{{ else }}{{ $msg }}{{ end }}
+      </div>
+    </dialog>
+    {{ else }}
     <div class="announcement-banner {{ $levelClass }}" data-announcement-id="{{ .id }}" role="alert">
       <span class="announcement-banner-message">
         {{ if .url }}<a href="{{ .url }}">{{ $msg }}</a>{{ else }}{{ $msg }}{{ end }}
@@ -21,5 +39,6 @@
         &times;
       </button>
     </div>
+    {{ end }}
   {{ end }}
 {{ end }}

--- a/layouts/partials/docs/inject/banner.html
+++ b/layouts/partials/docs/inject/banner.html
@@ -5,7 +5,7 @@
   {{/* Skip expired announcements */}}
   {{ $expired := false }}
   {{ with .expiresAt }}
-    {{ if time.AsTime . | lt $now }}{{ $expired = true }}{{ end }}
+    {{ if gt $now (time.AsTime .) }}{{ $expired = true }}{{ end }}
   {{ end }}
   {{ if not $expired }}
     {{ $msg := .message }}

--- a/layouts/partials/docs/inject/body.html
+++ b/layouts/partials/docs/inject/body.html
@@ -33,3 +33,20 @@
   });
 })();
 </script>
+
+<script>
+(function() {
+  // Announcement banner dismiss logic
+  document.querySelectorAll('.announcement-banner-close').forEach(function(btn) {
+    var id = btn.getAttribute('data-dismiss');
+    // Hide if already dismissed
+    if (localStorage.getItem('dismissed-' + id)) {
+      btn.parentElement.style.display = 'none';
+    }
+    btn.addEventListener('click', function() {
+      localStorage.setItem('dismissed-' + id, '1');
+      btn.parentElement.style.display = 'none';
+    });
+  });
+})();
+</script>

--- a/layouts/partials/docs/inject/body.html
+++ b/layouts/partials/docs/inject/body.html
@@ -1,0 +1,35 @@
+{{/* Back-to-top button */}}
+<button id="back-to-top" class="back-to-top"
+        aria-label="{{ i18n "BackToTop" | default "Back to top" }}"
+        title="{{ i18n "BackToTop" | default "Back to top" }}">
+  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"
+       fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"
+       stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
+</button>
+
+<script>
+(function() {
+  // Back to top
+  var btn = document.getElementById('back-to-top');
+  if (btn) {
+    window.addEventListener('scroll', function() {
+      btn.classList.toggle('visible', window.scrollY > 300);
+    }, { passive: true });
+
+    btn.addEventListener('click', function() {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+
+  // Listen for OS theme changes (only when no explicit preference stored)
+  var mq = window.matchMedia('(prefers-color-scheme: dark)');
+  mq.addEventListener('change', function(e) {
+    if (!localStorage.getItem('theme')) {
+      var theme = e.matches ? 'dark' : 'light';
+      document.documentElement.dataset.theme = theme;
+      var toggle = document.getElementById('theme-toggle');
+      if (toggle) toggle.checked = e.matches;
+    }
+  });
+})();
+</script>

--- a/layouts/partials/docs/inject/body.html
+++ b/layouts/partials/docs/inject/body.html
@@ -39,13 +39,33 @@
   // Announcement banner dismiss logic
   document.querySelectorAll('.announcement-banner-close').forEach(function(btn) {
     var id = btn.getAttribute('data-dismiss');
-    // Hide if already dismissed
     if (localStorage.getItem('dismissed-' + id)) {
       btn.parentElement.style.display = 'none';
     }
     btn.addEventListener('click', function() {
       localStorage.setItem('dismissed-' + id, '1');
       btn.parentElement.style.display = 'none';
+    });
+  });
+
+  // Announcement modal logic — auto-show on load, dismiss on button or backdrop click
+  document.querySelectorAll('dialog[data-announcement-id]').forEach(function(dialog) {
+    var id = dialog.dataset.announcementId;
+    if (!localStorage.getItem('dismissed-' + id)) {
+      dialog.showModal();
+    }
+    var closeBtn = dialog.querySelector('.announcement-modal-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function() {
+        localStorage.setItem('dismissed-' + id, '1');
+        dialog.close();
+      });
+    }
+    dialog.addEventListener('click', function(e) {
+      if (e.target === dialog) {
+        localStorage.setItem('dismissed-' + id, '1');
+        dialog.close();
+      }
     });
   });
 })();

--- a/layouts/partials/docs/inject/content-before.html
+++ b/layouts/partials/docs/inject/content-before.html
@@ -1,0 +1,11 @@
+{{/* Breadcrumb navigation */}}
+{{ if and (not .IsHome) .Parent }}
+<nav class="breadcrumb-nav" aria-label="Breadcrumb">
+  <ol>
+    {{ range .Ancestors.Reverse }}
+    <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
+    {{ end }}
+    <li aria-current="page">{{ .LinkTitle }}</li>
+  </ol>
+</nav>
+{{ end }}

--- a/layouts/partials/docs/inject/content-before.html
+++ b/layouts/partials/docs/inject/content-before.html
@@ -1,5 +1,5 @@
 {{/* Breadcrumb navigation */}}
-{{ if and (not .IsHome) .Parent }}
+{{ if and (not .IsHome) .Parent (not .Parent.IsHome) }}
 <nav class="breadcrumb-nav" aria-label="Breadcrumb">
   <ol>
     {{ range .Ancestors.Reverse }}

--- a/layouts/partials/docs/inject/content-before.html
+++ b/layouts/partials/docs/inject/content-before.html
@@ -1,3 +1,6 @@
+{{/* Announcement banners */}}
+{{ partial "docs/inject/banner" . }}
+
 {{/* Breadcrumb navigation */}}
 {{ if and (not .IsHome) .Parent (not .Parent.IsHome) }}
 <nav class="breadcrumb-nav" aria-label="Breadcrumb">

--- a/layouts/partials/docs/inject/head.html
+++ b/layouts/partials/docs/inject/head.html
@@ -1,0 +1,11 @@
+{{/* Anti-FOUC: detect and apply theme before first paint */}}
+<script>
+(function() {
+  var d = document.documentElement;
+  var t = localStorage.getItem('theme');
+  if (!t) {
+    t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  d.dataset.theme = t;
+})();
+</script>

--- a/layouts/partials/docs/inject/head.html
+++ b/layouts/partials/docs/inject/head.html
@@ -4,7 +4,7 @@
   var d = document.documentElement;
   var t = localStorage.getItem('theme');
   if (!t) {
-    t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    t = 'dark';
   }
   d.dataset.theme = t;
 })();

--- a/layouts/partials/font-toggle.html
+++ b/layouts/partials/font-toggle.html
@@ -1,28 +1,22 @@
-<!-- style="margin-top: 20px; margin-bottom: 10px;" -->
-
-<div>
-    <!--
-        Overriding the theme's rule (in _defaults.scss).
-        Without display: initial, the label defaults to display: flex,
-        causing the checkbox to wrap to a new line.
-    -->
-    <label for="font" style="display: initial;">
-        Font DSA
-    </label>
-    <input type="checkbox" name="font" id="font">
-</div>
+<label class="toggle-switch" title="Font DSA (OpenDyslexic)">
+  <input type="checkbox" name="font" id="font"
+         role="switch" aria-label="Font DSA (OpenDyslexic)">
+  <span class="toggle-switch-track">
+    <span class="toggle-switch-icon toggle-switch-icon--off" aria-hidden="true">Aa</span>
+    <span class="toggle-switch-icon toggle-switch-icon--on"  aria-hidden="true">Aa</span>
+    <span class="toggle-switch-thumb"></span>
+  </span>
+</label>
 
 <script>
-    addEventListener("DOMContentLoaded", (event) => { 
-    let fontElement = document.getElementById('font');
-
-    let isFontDSA = localStorage.getItem("isFontDSA");
-    if (isFontDSA) {
-        fontElement.checked = true; 
+addEventListener("DOMContentLoaded", function() {
+    var fontEl = document.getElementById('font');
+    if (!fontEl) return;
+    if (localStorage.getItem("isFontDSA")) {
+        fontEl.checked = true;
         document.body.classList.add('dyslexic');
     }
-
-    fontElement.addEventListener('click', function(e) {
+    fontEl.addEventListener('change', function() {
         if (this.checked) {
             document.body.classList.add('dyslexic');
             localStorage.setItem("isFontDSA", true);
@@ -30,6 +24,6 @@
             document.body.classList.remove('dyslexic');
             localStorage.removeItem("isFontDSA");
         }
-    })
-    })
+    });
+});
 </script>

--- a/layouts/partials/font-toggle.html
+++ b/layouts/partials/font-toggle.html
@@ -2,10 +2,9 @@
   <input type="checkbox" name="font" id="font"
          role="switch" aria-label="Font DSA (OpenDyslexic)">
   <span class="toggle-switch-track">
-    <span class="toggle-switch-icon toggle-switch-icon--off" aria-hidden="true">Aa</span>
-    <span class="toggle-switch-icon toggle-switch-icon--on"  aria-hidden="true">Aa</span>
     <span class="toggle-switch-thumb"></span>
   </span>
+  <span class="toggle-switch-icon" aria-hidden="true">Aa</span>
 </label>
 
 <script>

--- a/layouts/partials/font-toggle.html
+++ b/layouts/partials/font-toggle.html
@@ -4,7 +4,10 @@
   <span class="toggle-switch-track">
     <span class="toggle-switch-thumb"></span>
   </span>
-  <span class="toggle-switch-icon" aria-hidden="true">Aa</span>
+  <span class="toggle-switch-label">
+    <span class="toggle-switch-label--off">Aa Standard</span>
+    <span class="toggle-switch-label--on">Aa DSA</span>
+  </span>
 </label>
 
 <script>

--- a/layouts/partials/theme-toggle.html
+++ b/layouts/partials/theme-toggle.html
@@ -1,0 +1,23 @@
+<div>
+    <label for="theme-toggle" style="display: initial;">
+        {{ i18n "DarkMode" | default "Dark mode" }}
+    </label>
+    <input type="checkbox" name="theme-toggle" id="theme-toggle"
+           aria-label="{{ i18n "DarkMode" | default "Dark mode" }}">
+</div>
+
+<script>
+addEventListener("DOMContentLoaded", function() {
+    var toggle = document.getElementById('theme-toggle');
+    if (!toggle) return;
+
+    // Sync checkbox with current theme (set by inject/head.html)
+    toggle.checked = document.documentElement.dataset.theme === 'dark';
+
+    toggle.addEventListener('change', function() {
+        var theme = this.checked ? 'dark' : 'light';
+        document.documentElement.dataset.theme = theme;
+        localStorage.setItem('theme', theme);
+    });
+});
+</script>

--- a/layouts/partials/theme-toggle.html
+++ b/layouts/partials/theme-toggle.html
@@ -2,10 +2,10 @@
   <input type="checkbox" name="theme-toggle" id="theme-toggle"
          role="switch" aria-label="{{ i18n "DarkMode" | default "Dark mode" }}">
   <span class="toggle-switch-track">
-    <span class="toggle-switch-icon toggle-switch-icon--off" aria-hidden="true">☀️</span>
-    <span class="toggle-switch-icon toggle-switch-icon--on"  aria-hidden="true">🌙</span>
     <span class="toggle-switch-thumb"></span>
   </span>
+  <span class="toggle-switch-icon toggle-switch-icon--light" aria-hidden="true">☀️</span>
+  <span class="toggle-switch-icon toggle-switch-icon--dark"  aria-hidden="true">🌙</span>
 </label>
 
 <script>

--- a/layouts/partials/theme-toggle.html
+++ b/layouts/partials/theme-toggle.html
@@ -4,8 +4,10 @@
   <span class="toggle-switch-track">
     <span class="toggle-switch-thumb"></span>
   </span>
-  <span class="toggle-switch-icon toggle-switch-icon--light" aria-hidden="true">☀️</span>
-  <span class="toggle-switch-icon toggle-switch-icon--dark"  aria-hidden="true">🌙</span>
+  <span class="toggle-switch-label">
+    <span class="toggle-switch-label--off">☀️ Light</span>
+    <span class="toggle-switch-label--on">🌙 Dark</span>
+  </span>
 </label>
 
 <script>

--- a/layouts/partials/theme-toggle.html
+++ b/layouts/partials/theme-toggle.html
@@ -1,19 +1,18 @@
-<div>
-    <label for="theme-toggle" style="display: initial;">
-        {{ i18n "DarkMode" | default "Dark mode" }}
-    </label>
-    <input type="checkbox" name="theme-toggle" id="theme-toggle"
-           aria-label="{{ i18n "DarkMode" | default "Dark mode" }}">
-</div>
+<label class="toggle-switch" title="{{ i18n "DarkMode" | default "Dark mode" }}">
+  <input type="checkbox" name="theme-toggle" id="theme-toggle"
+         role="switch" aria-label="{{ i18n "DarkMode" | default "Dark mode" }}">
+  <span class="toggle-switch-track">
+    <span class="toggle-switch-icon toggle-switch-icon--off" aria-hidden="true">☀️</span>
+    <span class="toggle-switch-icon toggle-switch-icon--on"  aria-hidden="true">🌙</span>
+    <span class="toggle-switch-thumb"></span>
+  </span>
+</label>
 
 <script>
 addEventListener("DOMContentLoaded", function() {
     var toggle = document.getElementById('theme-toggle');
     if (!toggle) return;
-
-    // Sync checkbox with current theme (set by inject/head.html)
     toggle.checked = document.documentElement.dataset.theme === 'dark';
-
     toggle.addEventListener('change', function() {
         var theme = this.checked ? 'dark' : 'light';
         document.documentElement.dataset.theme = theme;

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "short_name": "Informatica",
+    "short_name": "SSN",
     "name": "sapienzastudents.net",
     "start_url": "/",
     "prefer_related_applications": false,

--- a/manifest.json
+++ b/manifest.json
@@ -24,31 +24,31 @@
             "purpose": "any maskable"
         },
         {
-            "src": "/icon-144.png",
+            "src": "/icon/icon-144.png",
             "type": "image/png",
             "sizes": "144x144",
             "purpose": "any maskable"
         },
         {
-            "src": "/icon-168.png",
+            "src": "/icon/icon-168.png",
             "type": "image/png",
             "sizes": "168x168",
             "purpose": "any maskable"
         },
         {
-            "src": "/icon-192.png",
+            "src": "/icon/icon-192.png",
             "type": "image/png",
             "sizes": "192x192",
             "purpose": "any maskable"
         },
         {
-            "src": "/icon-256.png",
+            "src": "/icon/icon-256.png",
             "type": "image/png",
             "sizes": "256x256",
             "purpose": "any maskable"
         },
         {
-            "src": "/icon-512.png",
+            "src": "/icon/icon-512.png",
             "type": "image/png",
             "sizes": "512x512",
             "purpose": "any maskable"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: 'selector',
+  darkMode: ['selector', '[data-theme="dark"]'],
   content: [
     "layouts/**/*.{html,js}",
     "cybersec/**/*.md",
@@ -11,12 +11,11 @@ module.exports = {
   theme: {
     extend: {
         colors: {
-            'primary': '#132441',
+            'primary': 'rgb(var(--tw-primary-rgb) / <alpha-value>)',
             'primary-dark': '#021330',
-            'accent': '#ffffff',
-            'diamond': '#2d58b5',
-            'faint': '#264281',
-            // 'faint': '#2d58b5'
+            'accent': 'rgb(var(--tw-accent-rgb) / <alpha-value>)',
+            'diamond': 'rgb(var(--tw-diamond-rgb) / <alpha-value>)',
+            'faint': 'rgb(var(--tw-faint-rgb) / <alpha-value>)',
         }
     },
   },


### PR DESCRIPTION
## Summary

Add a data-driven, dismissible announcement banner system. Announcements are defined in `data/announcements.json` and automatically rendered above page content.

> **Depends on:** #94 (`feat/theme-toggle-breadcrumbs`) → #93 → #91

## Features

- **Data-driven**: announcements defined in `data/announcements.json` with schema:
  ```json
  { "id": "unique-id", "level": "info|warning|critical", "message": "EN text",
    "messageIT": "IT text", "url": "optional link", "expiresAt": "optional ISO date" }
  ```
- **Auto-expiry**: announcements with `expiresAt` in the past are automatically hidden at build time
- **Dismissible**: close button hides banner and persists in `localStorage` by announcement ID
- **Severity levels**: `info` (blue), `warning` (amber), `critical` (red) — each with distinct left-border + tinted background
- **Localized**: uses `messageIT` for Italian language, `message` otherwise
- **Accessible**: `role="alert"`, min 44×44px close button, `:focus-visible` outline

## Files Changed

| File | Change |
|------|--------|
| `data/announcements.json` | **New** — announcement data (sample entry included) |
| `layouts/partials/docs/inject/banner.html` | **New** — banner rendering partial |
| `layouts/partials/docs/inject/content-before.html` | Include banner partial above breadcrumbs |
| `layouts/partials/docs/inject/body.html` | Dismiss JS appended |
| `assets/_custom.scss` | Banner CSS (3 severity levels, themed) |
| `i18n/*.yaml` (8 files) | `DismissBanner` key (EN: Dismiss / IT: Chiudi) |

## Testing

1. `docker compose up --build`
2. Sample banner appears above content on all hugo-book pages
3. Click × → banner dismissed, stays hidden after refresh
4. Clear `localStorage` → banner reappears
5. Set `expiresAt` to a past date → banner not shown
6. Works in both light and dark themes